### PR TITLE
Remove panics on invalid signatures

### DIFF
--- a/common/message-box/src/lib.rs
+++ b/common/message-box/src/lib.rs
@@ -103,6 +103,8 @@ pub enum MessageError {
   Incomplete,
   #[error("invalid encoding")]
   InvalidEncoding,
+  #[error("invalid encoding")]
+  InvalidSignature,
 }
 
 /// A Secure Message, defined as being not only encrypted yet authenticated.
@@ -299,17 +301,17 @@ impl<K: Copy + Eq + Hash + Debug + AsBytes> MessageBox<K> {
   }
 
   /// Decrypt a message, returning the contained byte vector.
-  pub fn decrypt_to_bytes(&self, from: &K, msg: SecureMessage) -> Vec<u8> {
+  pub fn decrypt_to_bytes(&self, from: &K, msg: SecureMessage) -> Option<Vec<u8>> {
     if !msg.sig.verify(
       self.pub_keys[from],
       signature_challenge(&self.our_name, msg.sig.R, self.pub_keys[from], &msg.iv, &msg.ciphertext),
     ) {
-      panic!("unauthorized/unintended message entered into an authenticated system");
+      return None;
     }
 
     let SecureMessage { iv, mut ciphertext, .. } = msg;
     XChaCha20::new(&self.enc_keys[from], &iv).apply_keystream(ciphertext.as_mut());
-    ciphertext
+    Some(ciphertext)
   }
 }
 

--- a/common/message-box/src/tests.rs
+++ b/common/message-box/src/tests.rs
@@ -36,7 +36,7 @@ macro_rules! message_box_test {
     {
       let msg = b"Hello, world!".to_vec();
       let enc = a_box.encrypt_bytes(&$B, msg.clone());
-      assert_eq!(msg, b_box.decrypt_to_bytes(&$A, enc.clone()));
+      assert_eq!(msg, b_box.decrypt_to_bytes(&$A, enc.clone()).unwrap());
 
       // Additionally test its serialize and serde support
       assert_eq!(enc, SecureMessage::new(enc.serialize()).unwrap());
@@ -46,7 +46,7 @@ macro_rules! message_box_test {
     // Generic API
     let msg = TestMessage { msg: "Hello, world!".into() };
     let enc = a_box.encrypt(&$B, &msg);
-    assert_eq!(msg, b_box.decrypt(&$A, enc));
+    assert_eq!(msg, b_box.decrypt(&$A, enc).unwrap());
 
     // Serialized API
     assert_eq!(msg, b_box.decrypt_from_slice(&$A, &a_box.encrypt_to_bytes(&$B, &msg)).unwrap());


### PR DESCRIPTION
Leftover from when this was solely internal which is now unsafe.